### PR TITLE
NoSQL Injection Fix

### DIFF
--- a/kadira-ui/server/methods/alerts.js
+++ b/kadira-ui/server/methods/alerts.js
@@ -1,6 +1,13 @@
 Meteor.methods({
   "alerts.create": function(alertInfo) {
-    check(alertInfo, Match.Any);
+    check(alertInfo, Match.ObjectIncluding({
+      meta: {
+        appId: String
+      },
+      rule: {
+        duration: Number
+      }
+    }));
 
     alertInfo.meta.enabled = true;
     setAppName(alertInfo);


### PR DESCRIPTION
Tightened up checking of `alertInfo` in the 'alerts.create' method.

Previously, `alertInfo` wasn't being thoroughly checked and `alertInfo.meta.appId` was being passed directly into `Apps.find`. A malicious user could manually call the `"alerts.create"` method, passing in a MongoDB query that could hang the database ([using `$where`](http://www.east5th.co/blog/2015/08/10/dos-your-meteor-application-with-where/)).