### PR TITLE
Enable ssl flag to connect MongoDB

### DIFF
--- a/init-shell.sh
+++ b/init-shell.sh
@@ -3,6 +3,7 @@ export APP_MONGO_URL="mongodb://app:password@candidate.53.mongolayer.com:10478,c
 export APP_MONGO_OPLOG_URL="mongodb://oplog:password@candidate.53.mongolayer.com:10478,candidate.54.mongolayer.com:10216/local?authSource=tkadira-app&replicaSet=set-56175e62147ca745d8000761"
 export DATA_MONGO_URL="mongodb://app:password@candidate.53.mongolayer.com:10478,candidate.54.mongolayer.com:10216/tkadira-data?replicaSet=set-56175e62147ca745d8000761"
 export MAIL_URL="smtp://postmaster%40kadira.io:9jx4fqhdfbg5@smtp.mailgun.org:587"
+export MONGO_SSL=false
 
 # Engine settings
 export ENGINE_PORT=11011

--- a/kadira-rma/start.sh
+++ b/kadira-rma/start.sh
@@ -27,6 +27,11 @@ if [[ -z $MONGO_SHARD ]]; then
   exit 1
 fi
 
+SSL_FLAG=""
+if [[ $MONGO_SSL == true ]]; then
+  SSL_FLAG="--ssl"
+fi
+
 ENV_FILE_NAME="env-$PROFILE-$PROVIDER.js"
 
 dumpEnvVarsTo() {
@@ -50,9 +55,9 @@ while [[ true ]]; do
   dumpEnvVarsTo $ENV_FILE_NAME
   set -x;
   if [ -z ${START_TIME+x} ] || [ -z ${END_TIME+x} ]; then
-      mongo $(pick-mongo-primary $MONGO_METRICS_URL) profiles/$PROFILE.js providers/$PROVIDER.js $ENV_FILE_NAME lib.js mapreduce.js incremental-aggregation.js;
+      mongo $(pick-mongo-primary $MONGO_METRICS_URL) $SSL_FLAG profiles/$PROFILE.js providers/$PROVIDER.js $ENV_FILE_NAME lib.js mapreduce.js incremental-aggregation.js;
   else
-      mongo $(pick-mongo-primary $MONGO_METRICS_URL) profiles/$PROFILE.js providers/$PROVIDER.js $ENV_FILE_NAME lib.js mapreduce.js batch-aggregation.js;
+      mongo $(pick-mongo-primary $MONGO_METRICS_URL) $SSL_FLAG profiles/$PROFILE.js providers/$PROVIDER.js $ENV_FILE_NAME lib.js mapreduce.js batch-aggregation.js;
   fi
   set +x;
   completedAt=$(date +%s)


### PR DESCRIPTION
I'm using MongoDB Atlas to store data for kadira.
Since MongoDB Atlas only support SSL enabled MongoDB, kadira-rma doesn't work properly.

This fix is for enabling ssl flag for kadira-rma by exporting `MONGO_SSL=true`.